### PR TITLE
check that cmake and perl are not too old for gpupack

### DIFF
--- a/gpupack
+++ b/gpupack
@@ -22,6 +22,7 @@ create_gpupack_sh
 # Install common libraries (architecture independent)
 
 # common_install
+common_check_versions
 
 # Choose a compiler
 

--- a/scripts/gpupack.common
+++ b/scripts/gpupack.common
@@ -75,4 +75,27 @@ function common_install ()
   vimpack_install
 }
 
+function check_cmake_version ()
+{
+  local res=$(cmake --version | head -n1 | awk '{split($3,a,".");print(a[1]==2 && a[2]<16);}')
+  if [ $res -eq 1 ]; then
+    echo "Your cmake is too old"
+    exit 1
+  fi
+}
+
+function check_perl_version ()
+{
+  local res=$(perl -e 'print $] <= 5.026?"1\n":"0\n";')
+  if [ $res -eq 1 ]; then
+    echo "Your perl is too old"
+    exit 1
+  fi
+}
+
+function common_check_versions ()
+{
+  check_cmake_version
+  check_perl_version
+}
 


### PR DESCRIPTION
Was fed up with gpupack stopping after minutes of works because cmake was too old.
It now checks much earlier if cmake (and perl) are not to old, and stop with a message it it's the case.